### PR TITLE
Fix with clang and related

### DIFF
--- a/c/perl_math_int128.c
+++ b/c/perl_math_int128.c
@@ -11,8 +11,6 @@
 #include "perl.h"
 #include "ppport.h"
 
-#if ((LONGSIZE >= 8) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)))
-
 #if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 6))
 
 /* workaround for gcc 4.4/4.5 - see http://gcc.gnu.org/gcc-4.4/changes.html */
@@ -112,17 +110,4 @@ perl_math_int128_load(int required_version) {
 
     return 1;
 }
-
-#else
-
-int
-perl_math_int128_load(int required_version) {
-    dTHX;
-    sv_setpv(ERRSV, "Unable to load Math::Int128 C API: your compiler does not support 128bit integers");
-    SvSETMAGIC(ERRSV);
-    return 0;
-}
-
-#endif
-
 

--- a/c/perl_math_int128.c
+++ b/c/perl_math_int128.c
@@ -11,16 +11,27 @@
 #include "perl.h"
 #include "ppport.h"
 
-#if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 6))
-
-/* workaround for gcc 4.4/4.5 - see http://gcc.gnu.org/gcc-4.4/changes.html */
-typedef int int128_t __attribute__ ((__mode__ (TI)));
-typedef unsigned int uint128_t __attribute__ ((__mode__ (TI)));
-
-#else
+/*
+ * Apparently clang supporting __int128 some time before defining
+ * __SIZEOF_INT128__.  Digging through their history is unhelpful, so I
+ * went by <https://gcc.gnu.org/ml/gcc-patches/2012-11/msg02197.html>.
+ */
+#if defined(__SIZEOF_INT128__) \
+ || (defined(__clang__) && (__clang_major__ * 100 + __clang_minor__ >= 302)) \
+ || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
 
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
+
+#else
+
+/*
+ * workaround for gcc 4.4/4.5 - see http://gcc.gnu.org/gcc-4.4/changes.html
+ * Should also apply to any other compiler that survives Build.PL and
+ * doesn't hit the above.
+ */
+typedef int int128_t __attribute__ ((__mode__ (TI)));
+typedef unsigned int uint128_t __attribute__ ((__mode__ (TI)));
 
 #endif
 


### PR DESCRIPTION
Code fails to properly setup int128 stuff with clang, for one major and one minor reason.

1) The entire initalization of the in128 stuff is wrapped in a conditional that stubs the whole thing out unless the compiler claims to be GCC 4.4+, but clang even as of 3.5 only claims to be 4.2:
    
    % clang35 -dM -E - < /dev/null | grep GNUC
    #define __GNUC_MINOR__ 2
    #define __GNUC_PATCHLEVEL__ 1
    #define __GNUC_STDC_INLINE__ 1
    #define __GNUC__ 4

  It seems to me that that entire wrapping #if is unnecessary, since it's basically attempting to provide a fallback for the case "I can't do int128", but that fallback apparently just causes it to blow up trying to load the XS anyway:

    % perl -MMaxMind::DB::Reader::XS -e 'print "OK\n"'
    ...
    /usr/local/lib/perl5/site_perl/mach/5.20/auto/MaxMind/DB/Reader/XS/XS.so: Undefined symbol "math_int128_c_api_newSVu128" at /usr/local/lib/perl5/5.20/XSLoader.pm line 68.

    % nm /usr/local/lib/perl5/site_perl/mach/5.20/auto/MaxMind/DB/Reader/XS/XS.so | grep 128_c_api
                 U math_int128_c_api_newSVu128

And if the compiler can't do int128, Build.PL should have already failed it anyway.  So I elected to remove the #if wrapping and the stub perl_math_int128_load() function as a whole.

2) Setting up the typedefs keyed only off "gcc 4.6+ has \__int128", whereas at least the last couple versions of clang have as well.  So I adjusted it to check for \__SIZEOF_INT128\__ (which should always signify having the typedef), with a fallback clang version check (because anecdata suggests it was around in that version, but \__SIZEOF_INT128\__ wasn't), and kept the GNUC version check as another fallback.  Order of condition branches reversed for readability with the longer condition.

  This would interact poorly with a compiler that tried to fallback to the ((\__mode\__ (TI))) method, but didn't support it.  I think that should be impossible because Build.PL would have already croaked.


Passes tests and appears to work right installed with real(-ish) code on FreeBSD with system compiler (clang 3.4.1), with clang 3.4.2, 3.5.0, and gcc 4.8.4.  Compiles cleanly and nm(1) shows the expected symbols on Debian with gcc 4.9.1 (various dependancies not in main package repos, so it's more involved for a full test).
