### PR TITLE
Check in newer perl_math_int128.c from Math::Int128

### DIFF
--- a/c/perl_math_int128.c
+++ b/c/perl_math_int128.c
@@ -1,17 +1,14 @@
 /*
  * perl_math_int128.c - This file is in the public domain
- * Author: Salvador Fandino <sfandino@yahoo.com>
+ * Author: "Salvador Fandino <sfandino@yahoo.com>, Dave Rolsky <autarch@urth.org>"
  *
- * Generated on: 2013-09-06 20:42:10
- * Math::Int128 version: 0.13
- * Module::CAPIMaker version: 0.02
+ * Generated on: 2015-04-07 16:08:19
+ * Math::Int128 version: 0.22
  */
 
 #include "EXTERN.h"
 #include "perl.h"
 #include "ppport.h"
-
-#if ((LONGSIZE >= 8) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)))
 
 #if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 6))
 
@@ -48,8 +45,7 @@ perl_math_int128_load(int required_version) {
 
     math_int128_c_api_hash = get_hv("Math::Int128::C_API", 0);
     if (!math_int128_c_api_hash) {
-        sv_setpv(ERRSV, "Unable to load Math::Int128 C API");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to load Math::Int128 C API");
         return 0;
     }
 
@@ -57,72 +53,52 @@ perl_math_int128_load(int required_version) {
     math_int128_c_api_max_version = SvIV(*hv_fetch(math_int128_c_api_hash, "max_version", 11, 1));
     if ((required_version < math_int128_c_api_min_version) ||
         (required_version > math_int128_c_api_max_version)) {
-        sv_setpvf(ERRSV, 
-                  "Math::Int128 C API version mismatch. "
-                  "The installed module supports versions %d to %d but %d is required",
-                  math_int128_c_api_min_version,
-                  math_int128_c_api_max_version,
-                  required_version);
-        SvSETMAGIC(ERRSV);
+        sv_setpvf_mg(ERRSV, 
+                     "Math::Int128 C API version mismatch. "
+                     "The installed module supports versions %d to %d but %d is required",
+                     math_int128_c_api_min_version,
+                     math_int128_c_api_max_version,
+                     required_version);
         return 0;
     }
 
     svp = hv_fetch(math_int128_c_api_hash, "SvI128", 6, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'SvI128' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'SvI128' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_SvI128 = INT2PTR(void *, SvIV(*svp));
     svp = hv_fetch(math_int128_c_api_hash, "SvI128OK", 8, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'SvI128OK' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'SvI128OK' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_SvI128OK = INT2PTR(void *, SvIV(*svp));
     svp = hv_fetch(math_int128_c_api_hash, "SvU128", 6, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'SvU128' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'SvU128' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_SvU128 = INT2PTR(void *, SvIV(*svp));
     svp = hv_fetch(math_int128_c_api_hash, "SvU128OK", 8, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'SvU128OK' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'SvU128OK' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_SvU128OK = INT2PTR(void *, SvIV(*svp));
     svp = hv_fetch(math_int128_c_api_hash, "newSVi128", 9, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'newSVi128' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'newSVi128' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_newSVi128 = INT2PTR(void *, SvIV(*svp));
     svp = hv_fetch(math_int128_c_api_hash, "newSVu128", 9, 0);
     if (!svp || !*svp) {
-        sv_setpv(ERRSV, "Unable to fetch pointer 'newSVu128' C function from Math::Int128");
-        SvSETMAGIC(ERRSV);
+        sv_setpv_mg(ERRSV, "Unable to fetch pointer 'newSVu128' C function from Math::Int128");
         return 0;
     }
     math_int128_c_api_newSVu128 = INT2PTR(void *, SvIV(*svp));
 
     return 1;
 }
-
-#else
-
-int
-perl_math_int128_load(int required_version) {
-    dTHX;
-    sv_setpv(ERRSV, "Unable to load Math::Int128 C API: your compiler does not support 128bit integers");
-    SvSETMAGIC(ERRSV);
-    return 0;
-}
-
-#endif
-
 


### PR DESCRIPTION
The older version of this file would not build the *int128 symbols under macOS (10.12), because `clang` reports an old version of gcc:

```
$ echo | clang -dM -E - | grep GNUC
#define __GNUC_MINOR__ 2
#define __GNUC_PATCHLEVEL__ 1
#define __GNUC_STDC_INLINE__ 1
#define __GNUC__ 4

$ clang --version
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin16.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Solve with the updated version of perl_math_int128.c with a different compiler check.

