### PR TITLE
Allow building with option install_base.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -4,7 +4,7 @@ use warnings;
 use lib 'inc';
 
 use Config::AutoConf;
-use Getopt::Long;
+use Getopt::Long qw( :config pass_through );
 use Module::Build;
 
 my $mb = Module::Build->new(


### PR DESCRIPTION
Working on a build/packaging system we ran into this issue during build.
