### PR TITLE
Reader-broken-databases.t fails with recent libmaxminddb.

### DIFF
--- a/t/MaxMind/DB/Reader-broken-databases.t
+++ b/t/MaxMind/DB/Reader-broken-databases.t
@@ -72,7 +72,9 @@ use Path::Class 0.27 qw( tempdir );
             $expect
                 = qr/Error opening database file "\Q$file\E": The MaxMind DB file contains invalid metadata .+/;
         }
-        else {
+        elsif (
+            version->parse($libmaxminddb_version) >= version->parse('1.1.2') )
+        {
             $expect
                 = qr/Error opening database file "\Q$file\E": The lookup path does not match the data .+/;
         }

--- a/t/MaxMind/DB/Reader-broken-databases.t
+++ b/t/MaxMind/DB/Reader-broken-databases.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use autodie;
+use version;
 
 use Test::Fatal;
 use Test::More;
@@ -60,18 +61,18 @@ use Path::Class 0.27 qw( tempdir );
     ## no critic (Subroutines::ProhibitCallsToUnexportedSubs, Modules::RequireExplicitInclusion)
     if ( Module::Implementation::implementation_for('MaxMind::DB::Reader') eq
         'XS' ) {
-        my ( undef, $minor, $patch ) = (
-            split /\./,
-            MaxMind::DB::Reader::XS::libmaxminddb_version()
-        );
+        my $libmaxminddb_version
+            = MaxMind::DB::Reader::XS::libmaxminddb_version();
 
         # Newer versions of libmaxminddb do better error checking and so end
         # up throwing a different error on this garbage file.
-        if ( $minor >= 1 && $patch >= 3 ) {
+        if (
+            version->parse($libmaxminddb_version) >= version->parse('1.1.3') )
+        {
             $expect
                 = qr/Error opening database file "\Q$file\E": The MaxMind DB file contains invalid metadata .+/;
         }
-        elsif ( $minor >= 1 && $patch >= 2 ) {
+        else {
             $expect
                 = qr/Error opening database file "\Q$file\E": The lookup path does not match the data .+/;
         }


### PR DESCRIPTION
There is a problem that misunderstand as an old libmaxminddb.

```
 # It is expected to become true when libmaxminddb 1.1.3+
 if ( $minor >= 1 && $patch >= 3 ) { 
     $expect 
         = qr/Error opening database file "\Q$file\E": The MaxMind DB file contains invalid metadata .+/; 
 } 
```

No problem with libmaxminddb 1.1.x

  * version 1.1.4:  ```if ( $minor >= 1 && $patch >= 3) is true```
  * version 1.1.2:  ```if ( $minor >= 1 && $patch >= 3) is false```

However, there is a problem when using libmaxminddb 1.2.0+

  * version 1.3.2:  ```if ( $minor >= 1 && $patch >= 3 ) is false```
  * version 1.2.0:  ```if ( $minor >= 1 && $patch >= 3) is false```

I think this patch to fix issue #21.
