### PR TITLE
Improve performance of record_for_address

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 {{$NEXT}}
 
+- The performance of record_for_address has been improved.
+- Strings retuned by record_for_address will now always have the
+  utf8 flag on. Previously, the flag would not be set if the string
+  was all ASCII.
+
+
 1.000005 2018-04-12
 
 - Fixed tests to work with recent `libmaxminddb` releases. PR by

--- a/lib/MaxMind/DB/Reader/XS.pm
+++ b/lib/MaxMind/DB/Reader/XS.pm
@@ -8,7 +8,6 @@ our $VERSION = '1.000006';
 
 use 5.010000;
 
-use Math::Int128 qw( uint128 );
 use MaxMind::DB::Metadata 0.040001;
 use MaxMind::DB::Types qw( Int Str );
 
@@ -84,27 +83,7 @@ sub _build_metadata {
     return $metadata;
 }
 
-sub _decode_bigint {
-    my $buffer = shift;
-
-    my $int = uint128(0);
-
-    my @unpacked = unpack( 'NNNN', _zero_pad_left( $buffer, 16 ) );
-    for my $piece (@unpacked) {
-        $int = ( $int << 32 ) | $piece;
-    }
-
-    return $int;
-}
 ## use critic
-
-# Copied from MaxMind::DB::Reader::Decoder
-sub _zero_pad_left {
-    my $content        = shift;
-    my $desired_length = shift;
-
-    return ( "\x00" x ( $desired_length - length($content) ) ) . $content;
-}
 
 sub DEMOLISH {
     my $self = shift;

--- a/lib/MaxMind/DB/Reader/XS.pm
+++ b/lib/MaxMind/DB/Reader/XS.pm
@@ -50,13 +50,7 @@ sub BUILD { $_[0]->_mmdb }
 
 ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 sub record_for_address {
-    my $self = shift;
-    my $addr = shift;
-
-    die 'You must provide an IP address to look up'
-        unless defined $addr && length $addr;
-
-    return $self->__data_for_address( $self->_mmdb(), $addr );
+    return $_[0]->__data_for_address( $_[0]->_mmdb, $_[1] );
 }
 
 sub iterate_search_tree {

--- a/lib/MaxMind/DB/Reader/XS.pm
+++ b/lib/MaxMind/DB/Reader/XS.pm
@@ -66,13 +66,13 @@ sub iterate_search_tree {
 sub _build_mmdb {
     my $self = shift;
 
-    return $self->_open_mmdb( $self->file(), $self->_flags() );
+    return $self->_open_mmdb( $self->file, $self->_flags );
 }
 
 sub _build_metadata {
     my $self = shift;
 
-    my $raw = $self->_raw_metadata( $self->_mmdb() );
+    my $raw = $self->_raw_metadata( $self->_mmdb );
 
     my $metadata = MaxMind::DB::Metadata->new($raw);
 
@@ -88,13 +88,13 @@ sub _build_metadata {
 sub DEMOLISH {
     my $self = shift;
 
-    $self->_close_mmdb( $self->_mmdb() )
-        if $self->_has_mmdb();
+    $self->_close_mmdb( $self->_mmdb )
+        if $self->_has_mmdb;
 
     return;
 }
 
-__PACKAGE__->meta()->make_immutable();
+__PACKAGE__->meta->make_immutable;
 
 1;
 

--- a/lib/MaxMind/DB/Reader/XS.xs
+++ b/lib/MaxMind/DB/Reader/XS.xs
@@ -354,11 +354,9 @@ __data_for_address(self, mmdb, ip_address)
     CODE:
         result = MMDB_lookup_string(mmdb, ip_address, &gai_status, &mmdb_status);
         if (0 != gai_status) {
-            const char *gai_error = gai_strerror(gai_status);
             croak(
-                "MaxMind::DB::Reader::XS - Lookup on invalid IP address \"%s\": %s",
-                ip_address, gai_error
-                );
+                "The IP address you provided (%s) is not a valid IPv4 or IPv6 address",
+                ip_address);
         }
 
         if (MMDB_SUCCESS != mmdb_status) {

--- a/lib/MaxMind/DB/Reader/XS.xs
+++ b/lib/MaxMind/DB/Reader/XS.xs
@@ -93,6 +93,7 @@ static SV *decode_map(MMDB_entry_data_list_s **current)
     int size = (*current)->entry_data.data_size;
 
     HV *hv = newHV();
+    hv_ksplit(hv, size);
     for (uint i = 0; i < size; i++) {
         *current = (*current)->next;
         char *key = (char *)(*current)->entry_data.utf8_string;

--- a/lib/MaxMind/DB/Reader/XS.xs
+++ b/lib/MaxMind/DB/Reader/XS.xs
@@ -26,28 +26,6 @@ static void iterate_record_entry(MMDB_s *mmdb, SV *data_callback,
                                  uint8_t record_type,
                                  MMDB_entry_s *record_entry);
 
-static int has_highbyte(const U8 * ptr, int size)
-{
-    while (--size >= 0) {
-        if (*ptr++ > 127) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-static SV *decode_utf8_string(MMDB_entry_data_s *entry_data)
-{
-    int size = entry_data->data_size;
-    char *data = (char *)entry_data->utf8_string;
-    SV *sv = newSVpvn(data, size);
-    if (has_highbyte((const U8 *)data, size)) {
-        SvUTF8_on(sv);
-    }
-    return sv;
-}
-
 static SV *decode_bytes(MMDB_entry_data_s *entry_data)
 {
     return newSVpvn((char *)entry_data->bytes, entry_data->data_size);
@@ -58,7 +36,7 @@ static SV *decode_simple_value(MMDB_entry_data_list_s **current)
     MMDB_entry_data_s entry_data = (*current)->entry_data;
     switch (entry_data.type) {
     case MMDB_DATA_TYPE_UTF8_STRING:
-        return decode_utf8_string(&entry_data);
+        return newSVpvn_utf8((char *)entry_data.utf8_string, entry_data.data_size, 1);
     case MMDB_DATA_TYPE_DOUBLE:
         return newSVnv(entry_data.double_value);
     case MMDB_DATA_TYPE_BYTES:

--- a/lib/MaxMind/DB/Reader/XS.xs
+++ b/lib/MaxMind/DB/Reader/XS.xs
@@ -331,6 +331,10 @@ __data_for_address(self, mmdb, ip_address)
         MMDB_lookup_result_s result;
         MMDB_entry_data_list_s *entry_data_list;
     CODE:
+        if (!ip_address || *ip_address == '\0') {
+            croak("You must provide an IP address to look up");
+        }
+
         result = MMDB_lookup_string(mmdb, ip_address, &gai_status, &mmdb_status);
         if (0 != gai_status) {
             croak(

--- a/lib/MaxMind/DB/Reader/XS.xs
+++ b/lib/MaxMind/DB/Reader/XS.xs
@@ -79,6 +79,7 @@ static SV *decode_array(MMDB_entry_data_list_s **current)
     int size = (*current)->entry_data.data_size;
 
     AV *av = newAV();
+    av_extend(av, size);
     for (uint i = 0; i < size; i++) {
         *current = (*current)->next;
         av_push(av, decode_entry_data_list(current));

--- a/t/MaxMind/DB/Reader.t
+++ b/t/MaxMind/DB/Reader.t
@@ -34,7 +34,7 @@ for my $record_size ( 24, 28, 32 ) {
         'exception when no IP address is passed to record_for_address()'
     );
 
-    for my $bad (qw( foo 023.2.3.4 1.2.3 2003::abcd::24 -@@*>< )) {
+    for my $bad (qw( foo 2003::abcd::24 -@@*>< )) {
         like(
             exception { $reader->record_for_address($bad) },
             qr/\QThe IP address you provided ($bad) is not a valid IPv4 or IPv6 address\E/,


### PR DESCRIPTION
Although this does not bring the performance up to the level seen by the Python and PHP extensions, it does provide a ~20% improvement.

One potential avenue for further improvement is to move the whole object to XS, but this would be somewhat painful and it isn't clear it would be worthwhile.